### PR TITLE
A fix to skip empty chunks while training models

### DIFF
--- a/src/typilus/model/model.py
+++ b/src/typilus/model/model.py
@@ -454,6 +454,11 @@ class Model(ABC):
             cur_chunk_idx = (cur_chunk_idx + 1) % len(open_chunks_info)
             cur_chunk_info = open_chunks_info[cur_chunk_idx]
 
+            # Skip empty chunks
+            if len(cur_chunk_info.sample_idx_list) == 0:
+                del (open_chunks_info[cur_chunk_idx])
+                continue
+
             # Get next sample:
             cur_sample = cur_chunk_info.data[cur_chunk_info.sample_idx_list[cur_chunk_info.samples_used_so_far[0]]]
             cur_batch_data['samples_in_batch'] += 1


### PR DESCRIPTION
Hi,
Thanks for sharing the code.

I have carefully followed the README file to create tensors and train the `Typilus` model. Yet an empty chunk causes an exception in method `__raw_batches_from_chunks_iterator`. Specifically, the next sample could not be retrieved [here](https://github.com/typilus/typilus/blob/9d1cb5db846e8230d0ed8e877021ebf80ea42df6/src/typilus/model/model.py#L458), due to an empty chunk. I have managed to solve this issue by skipping empty chunks and the model's training was successful. Also, the obtained results were okay. I should note that I used a different larger dataset that has type annotations.
However, I am not sure whether this is the right way to fix the mentioned issue, and why some chunks ended up being empty.
All in all, I have decided to send a pull request for fixing the issue or at least to report the issue.
